### PR TITLE
Cache tags, Update README, polish stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,84 @@
 # Composer Version Manager
 
 [Composer 2](https://getcomposer.org/upgrade/UPGRADE-2.0.md) is here. It's time for a one stop shop for switching between major (and minor 
-👶) composer versions.
+👶) composer versions. Erase "using the right composer version" from your workflow.
 
 > But wait, what about `composer self-update --1` and `--2`?
 
 Well I'm glad you've asked!
 
-There are some added benefits this CLI will bring to you:
+There are some added benefits this CLI and shell hook will bring to you:
 
 1. Cached `composer.phar` for faster version toggling.
-1. Per-directory automated and configurable context switching.
-1. Production and pipeline friendly installation via [Docker](https://hub.docker.com/).
-1. It's as simple as `cvm 1` and `cvm 2`.
+1. Per-directory smart composer environments. It's as simple as `cd my-project` and the right composer version will be used.
 
-## Author
+## Installation
 
-My name is Morgan Wowk and I am a Software Developer from the wintery lands of Canada 🇨🇦🍁. You can primarily find me on [LinkedIn](https://www.linkedin.com/in/morganwowk/), writing open source or building apps to help [tens of thousands of ecommerce stores](https://boldcommerce.com/).
+Choose one of the options below to install cvm.
 
-## Usage
+### Homebrew (MacOS)
 
-```
-# All the commands below will install the missing
-# version if it is not yet installed.
-
-cvm 1               # Use the latest, stable composer 1
-cvm 2               # Use the latest, stable composer 2
-cvm 1.0.0-alpha7    # Use a specific release
+```bash
+brew update
+brew install composer-version-manager/cvm
 ```
 
+### Chocolatey (Windows)
+
+*TODO*
+
+### Download binary and update PATH
+
+*TODO*
+
+## Hook onto your shell
+
+Hooking onto your shell enables cvm [Smart usage](#smart-usage) for per-directory automated composer verrsioning.
+
+Find the instructions for your shell below. If your shell is not listed please feel free to [submit a feature request](https://github.com/composer-version-manager/cvm/issues/new) issue and we will try and make it happen.
+
+### **BASH**
+
+Add the following line to the end of your `~/.bashrc`
+
+```bash
+eval "$(cvm hook bash)"
+```
+
+### **ZSH**
+
+Add the following line to the end of your `~/.zshrc`
+
+```bash
+eval "$(cvm hook zsh)"
+```
+
+## Smart usage
+
+Create a `.cvm_config` in any directory specifying the composer version you would like to use. Navigating to that directory or any nested directory will automatically enable that composer version in your current workspace.
+
+```bash
+cd my-project
+echo '2.0.11' > .cvm_config
+```
+
+This file can be committed to your source control.
+
+## Global composer version
+
+You can configure a global composer version. Which will be the default when no parent directory has a `.cvm_config`.
+
+```
+cvm list        # List available tags
+cvm use 2.0.11  # Globally use a specific composer version
+```
+
+## Authors
+
+### Morgan Wowk
+
+Morgan is a Software Developer from the wintery lands of Canada 🇨🇦🍁. You can primarily find him on [LinkedIn](https://www.linkedin.com/in/morganwowk/), writing open source or building apps to help [tens of thousands of ecommerce stores](https://boldcommerce.com/).
+
+### Bhavek Budhia
+
+Likewise, Bhavek resides in the frosty country of Canada ☃️. An avid developer 👨‍💻 with fortified experience in Python that has helped us develop a clean and extendable codebase.

--- a/cvm/cli.py
+++ b/cvm/cli.py
@@ -6,6 +6,7 @@ from typing import Optional
 from argparse_color_formatter import ColorRawTextHelpFormatter
 from colorama import Fore
 
+from cvm.commands.cache_command import CacheCommand
 from cvm.commands.command import Command
 from cvm.commands.hook_command import HookCommand
 from cvm.commands.list_command import ListCommand
@@ -15,14 +16,15 @@ from cvm.helpers.cli import colored_fore
 from cvm.services.cache_service import CacheService
 
 COMMAND_NAME = 'cvm'
-COMMAND_DESC = 'Composer Version Manager\n' + colored_fore(Fore.WHITE, 'Author: @game-of-morgan (Morgan Wowk)')
+COMMAND_DESC = 'Composer Version Manager\n' + colored_fore(Fore.WHITE, 'Authors: @game-of-morgan (Morgan Wowk), @ubaniak (Bhavek Budhia)')
 COMMAND_EPILOG = 'https://github.com/game-of-morgan/cvm\n\nSupport this project by giving it a GitHub star ⭐️'
 
 COMMANDS = {
     UseCommand.NAME: UseCommand,
     ScanCommand.NAME: ScanCommand,
     ListCommand.NAME: ListCommand,
-    HookCommand.NAME: HookCommand
+    HookCommand.NAME: HookCommand,
+    CacheCommand.NAME: CacheCommand
 }
 
 

--- a/cvm/commands/cache_command.py
+++ b/cvm/commands/cache_command.py
@@ -1,0 +1,25 @@
+from argparse import Action, Namespace
+
+from cvm.commands.command import Command
+from cvm.helpers.cli import info, warning
+from cvm.services.cache_service import CacheService
+from cvm.services.composer_service import ComposerService
+from cvm.services.github_service import GitHubService
+
+
+class CacheCommand(Command):
+    NAME = 'cache:clear'
+    DESCRIPTION = 'Cleared cached composer tags.'
+
+    def exec(self, args: Namespace):
+        try:
+            GitHubService.TAGS_FILE_PATH.unlink(missing_ok=True)
+        except OSError:
+            print(warning("Failed to clear cached tags."))
+            return
+
+        print(info("Cached tags successfully cleared."))
+
+    @staticmethod
+    def define_signature(parser: Action):
+        parser.add_parser(CacheCommand.NAME, help=CacheCommand.DESCRIPTION)

--- a/cvm/commands/scan_command.py
+++ b/cvm/commands/scan_command.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from colorama import Fore
 from cvm.commands.command import Command
-from cvm.helpers.cli import warning
+from cvm.helpers.cli import info, warning
 from cvm.helpers.fs import find_file_in_parent
 from cvm.services.application_service import ApplicationService
 from cvm.services.composer_service import ComposerService
@@ -31,7 +31,12 @@ class ScanCommand(Command):
         composer_service = ComposerService(github_service)
         updated_path = composer_service.use_version(version, False)
 
-        print(f"export PATH=\"{updated_path}\"; echo Updated path.;")
+        if not updated_path:
+            return
+        
+        msg = info(f"Using composer version {version}")
+
+        print(f"export PATH=\"{updated_path}\"; echo \"{msg}\";")
 
     def _check_local(self, config_file: str) -> Optional[str]:
         data = ConfigService.read(config_file)

--- a/cvm/commands/use_command.py
+++ b/cvm/commands/use_command.py
@@ -3,11 +3,10 @@ import subprocess
 from argparse import Action, Namespace
 
 from cvm.commands.command import Command
+from cvm.helpers.cli import info
 from cvm.services.composer_service import ComposerService
 from cvm.services.config_service import ConfigService
 from cvm.services.github_service import GitHubService
-from cvm.helpers.cli import info
-from colorama import Fore
 
 
 class UseCommand(Command):
@@ -22,7 +21,7 @@ class UseCommand(Command):
 
         composer_service.use_version(version, True)
 
-        print(f"Global composer version updated to {version}.")
+        print(info(f"Global composer version updated to {version}."))
 
     @staticmethod
     def define_signature(parser: Action):

--- a/cvm/helpers/cli.py
+++ b/cvm/helpers/cli.py
@@ -6,7 +6,7 @@ def colored_fore(color: AnsiFore, text: str, default: str = Fore.LIGHTWHITE_EX) 
     return color + text + default
 
 def warning(text: str, default: str = Fore.LIGHTWHITE_EX) -> str:
-    return colored_fore(Fore.LIGHTRED_EX, text)
+    return colored_fore(Fore.LIGHTRED_EX, f"cvm: {text}")
 
 def info(text: str, default: str = Fore.LIGHTWHITE_EX) -> str:
-    return colored_fore(Fore.LIGHTYELLOW_EX, text)
+    return colored_fore(Fore.LIGHTYELLOW_EX, f"cvm: {text}")

--- a/cvm/services/composer_service.py
+++ b/cvm/services/composer_service.py
@@ -2,12 +2,12 @@ import logging
 import pathlib
 import subprocess
 import sys
+from typing import Optional
 
 import requests
-
+from cvm.services.application_service import ApplicationService, ComposerSource
 from cvm.services.cache_service import CacheService
 from cvm.services.github_service import GitHubService
-from cvm.services.application_service import ApplicationService, ComposerSource
 
 
 class ComposerService:
@@ -69,10 +69,15 @@ class ComposerService:
 
         return str(cache_path)
 
-    def use_version(self, tag_name: str, is_global: bool) -> str:
-        bin_path = self.install_version(tag_name, quiet=True)
-
+    def use_version(self, tag_name: str, is_global: bool) -> Optional[str]:
         application_service = ApplicationService()
+
+        bin_path = self.install_version(tag_name, quiet=True)
+        current_tag_name = application_service.get('current')
+
+        if not is_global and current_tag_name == tag_name:
+            return None
+
         application_service.set('current', tag_name)
 
         if is_global:

--- a/cvm/services/github_service.py
+++ b/cvm/services/github_service.py
@@ -1,19 +1,23 @@
+import json
 import logging
 import sys
 from typing import Generator
 
 import requests
+from cvm.services.application_service import ApplicationService
 
 
 class GitHubService:
+    TAGS_FILE_PATH = ApplicationService.APP_DIR / 'tags.json'
+
     def __init__(self, owner_id: str, repo_id: str):
         self.owner_id = owner_id
         self.repo_id = repo_id
 
-    def list_tags(self) -> Generator[object]:
-
+    def _fetch_tags(self) -> Generator[object, None, None]:
         page = 1
         headers = {'Accept': 'application/vnd.github.v3+json'}
+
         while True:
 
             url = f"https://api.github.com/repos/{self.owner_id}/{self.repo_id}/tags?page={page}"
@@ -31,3 +35,20 @@ class GitHubService:
                 yield i
             page += 1
 
+    def list_tags(self) -> Generator[object, None, None]:
+        if GitHubService.TAGS_FILE_PATH.exists():
+            cache = json.load(GitHubService.TAGS_FILE_PATH.open('r'))
+            tags = cache["tags"]
+
+            for tag in tags:
+                yield tag
+        else:
+            tags = []
+            for tag in self._fetch_tags():
+                tags.append(tag)
+                yield tag
+            
+            cache = {
+                "tags": tags
+            }
+            GitHubService.TAGS_FILE_PATH.write_text(json.dumps(cache))


### PR DESCRIPTION
**Changes:**

* Composer tags will now be cached in a `~/.cvm/tags.json` file
* `cvm cache:clear` will clear cached tags
* Update README to have install and usage instructions
* Update README author bios
* Clean up messaging to stdout
* Only update PATH and echo to stdout when current version changes